### PR TITLE
[Wait for dune 2.5] Add compatibility with ocaml 4.02.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add compatibility up-to OCaml 4.02.3 (with disabled tests). (#1, @voodoos)
+
 # 1.0.0
 
 - Initial release

--- a/csexp.opam
+++ b/csexp.opam
@@ -29,9 +29,10 @@ homepage: "https://github.com/diml/csexp"
 doc: "https://diml.github.io/csexp/"
 bug-reports: "https://github.com/diml/csexp/issues"
 depends: [
-  "dune" {>= "2.0"}
-  "ocaml" {>= "4.04.0"}
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.02.3"}
   "ppx_expect" {with-test}
+  "result" {>= "1.5"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.5)
 (name csexp)
 
 (license MIT)
@@ -15,8 +15,9 @@
 (package
  (name csexp)
  (depends
-   (ocaml (>= 4.04.0))
-   (ppx_expect :with-test))
+   (ocaml (>= 4.02.3))
+   (ppx_expect :with-test)
+   (result (>= 1.5)))
  (synopsis "Parsing and printing of S-expressions in Canonical form")
  (description "
 This library provides minimal support for Canonical S-expressions

--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -6,6 +6,7 @@ end
 
 module Make (Sexp : Sexp) = struct
   open Sexp
+  include Result
 
   module type Input = sig
     type t

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -27,6 +27,7 @@ module type Sexp = sig
 end
 
 module Make (Sexp : Sexp) : sig
+  include module type of Result
   (** {2 Parsing} *)
 
   (** [parse_string s] parses a single S-expression encoded in canonical form in

--- a/src/dune
+++ b/src/dune
@@ -1,2 +1,3 @@
 (library
- (public_name csexp))
+ (public_name csexp)
+ (libraries result))

--- a/test/dune
+++ b/test/dune
@@ -2,4 +2,5 @@
  (name csexp_tests)
  (libraries csexp)
  (inline_tests)
+ (enabled_if (>= %{ocaml_version} 4.04.0))
  (preprocess (pps ppx_expect)))


### PR DESCRIPTION
This is needed for [use with merlin ](https://github.com/ocaml/merlin/pull/1123).

- Tests are disabled if OCaml version is < 4.04.0
- The [result](https://opam.ocaml.org/packages/result/) package is used to ensure compat with OCaml < 4.03.0.

This necessitate a future version of dune: probably  `2.5`.