### PR TITLE
Support monadic inputs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Expose low level, monad agnostic parser. (#2, @mefyl)
+
 # 1.1.0
 
 - Add compatibility up-to OCaml 4.02.3 (with disabled tests). (#1, @voodoos)

--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -21,16 +21,14 @@ module Make (Sexp : Sexp) = struct
 
     module Monad : Monad
 
-    val read_string : t -> int -> string Monad.t
+    val read_string : t -> int -> (string, string) result Monad.t
 
-    val read_char : t -> char Monad.t
+    val read_char : t -> (char, string) result Monad.t
   end
 
-  exception Parse_error of string
+  let parse_error msg = Format.ksprintf Result.error msg
 
-  let parse_error msg = raise_notrace (Parse_error msg)
-
-  let invalid_character () = parse_error "invalid character"
+  let invalid_character c = parse_error "invalid character %C" c
 
   let missing_left_parenthesis () =
     parse_error "right parenthesis without matching left parenthesis"
@@ -40,40 +38,50 @@ module Make (Sexp : Sexp) = struct
 
     let rec parse_atom input len =
       Input.Monad.bind (Input.read_char input) @@ function
-      | '0' .. '9' as c ->
+      | Result.Ok c when '0' <= c && c <= '9' ->
         let len = (len * 10) + int_of_digit c in
         if len > Sys.max_string_length then
-          parse_error "atom too big to represent"
+          Input.Monad.return @@ parse_error "atom too big to represent"
         else
           parse_atom input len
-      | ':' ->
-        Input.Monad.bind (Input.read_string input len) @@ fun s ->
-        Input.Monad.return @@ Atom s
-      | _ -> invalid_character ()
+      | Result.Ok ':' -> (
+        Input.Monad.bind (Input.read_string input len) @@ function
+        | Result.Ok s -> Input.Monad.return @@ Result.ok @@ Atom s
+        | Result.Error e -> Input.Monad.return @@ Result.Error e )
+      | Result.Ok c -> Input.Monad.return @@ invalid_character c
+      | Result.Error e -> Input.Monad.return @@ Result.Error e
 
-    let rec parse_many input depth acc =
+    let rec parse_many depth input acc =
       Input.Monad.bind (Input.read_char input) @@ function
-      | '(' ->
-        Input.Monad.bind (parse_many input (depth + 1) []) @@ fun sexps ->
-        parse_many input (depth + 1) (List sexps :: acc)
-      | ')' ->
+      | Result.Ok '(' -> (
+        Input.Monad.bind (parse_many (depth + 1) input []) @@ function
+        | Result.Ok sexps -> parse_many (depth + 1) input @@ (List sexps :: acc)
+        | e -> Input.Monad.return e )
+      | Result.Ok ')' ->
         if depth = 0 then
-          missing_left_parenthesis ()
+          Input.Monad.return @@ missing_left_parenthesis ()
         else
-          Input.Monad.return @@ List.rev acc
-      | '0' .. '9' as c ->
-        Input.Monad.bind (parse_atom input (int_of_digit c)) @@ fun sexp ->
-        parse_many input depth (sexp :: acc)
-      | _ -> invalid_character ()
+          Input.Monad.return @@ Result.ok @@ List.rev acc
+      | Result.Ok c when '0' <= c && c <= '9' -> (
+        Input.Monad.bind (parse_atom input (int_of_digit c)) @@ function
+        | Result.Ok sexp -> parse_many depth input (sexp :: acc)
+        | Result.Error e -> Input.Monad.return @@ Result.Error e )
+      | Result.Ok c -> Input.Monad.return @@ invalid_character c
+      | Result.Error e -> Input.Monad.return @@ Result.Error e
 
     let parse input =
       Input.Monad.bind (Input.read_char input) @@ function
-      | '(' ->
-        Input.Monad.bind (parse_many input 1 []) @@ fun sexps ->
-        Input.Monad.return @@ List sexps
-      | ')' -> missing_left_parenthesis ()
-      | '0' .. '9' as c -> parse_atom input (int_of_digit c)
-      | _ -> invalid_character ()
+      | Result.Ok '(' -> (
+        Input.Monad.bind (parse_many 1 input []) @@ function
+        | Result.Ok sexps -> Input.Monad.return @@ Result.ok @@ List sexps
+        | Result.Error e -> Input.Monad.return @@ Result.Error e )
+      | Result.Ok ')' -> Input.Monad.return @@ missing_left_parenthesis ()
+      | Result.Ok c when '0' <= c && c <= '9' ->
+        parse_atom input (int_of_digit c)
+      | Result.Ok c -> Input.Monad.return @@ invalid_character c
+      | Result.Error e -> Input.Monad.return @@ Result.Error e
+
+    let parse_many input = parse_many 0 input []
   end
   [@@inlined always]
 
@@ -97,19 +105,21 @@ module Make (Sexp : Sexp) = struct
 
     let read_string t len =
       let pos = t.pos in
-      let s = String.sub t.buf pos len in
-      t.pos <- pos + len;
-      s
+      if pos + len <= String.length t.buf then (
+        let s = String.sub t.buf pos len in
+        t.pos <- pos + len;
+        Result.Ok s
+      ) else
+        Result.Error premature_end
 
     let read_char t =
-      let pos = t.pos in
-      let c = t.buf.[pos] in
-      t.pos <- pos + 1;
-      c
-
-    let error_of_exn t = function
-      | Parse_error msg -> Error (t.pos, msg)
-      | _ -> Error (t.pos, premature_end)
+      if t.pos + 1 <= String.length t.buf then (
+        let pos = t.pos in
+        let c = t.buf.[pos] in
+        t.pos <- pos + 1;
+        Result.Ok c
+      ) else
+        Result.Error premature_end
   end
 
   module String_parser = Make_parser (String_input)
@@ -117,27 +127,31 @@ module Make (Sexp : Sexp) = struct
   let parse_string s =
     let input : String_input.t = { buf = s; pos = 0 } in
     match String_parser.parse input with
-    | x ->
+    | Ok parsed ->
       if input.pos <> String.length s then
         Error (input.pos, "data after canonical S-expression")
       else
-        Ok x
-    | exception e -> String_input.error_of_exn input e
+        Ok parsed
+    | Error msg -> Error (input.pos, msg)
 
   let parse_string_many s =
     let input : String_input.t = { buf = s; pos = 0 } in
-    match String_parser.parse_many input 0 [] with
-    | l -> Ok (List.rev l)
-    | exception e -> String_input.error_of_exn input e
+    String_parser.parse_many input
+    |> Result.map List.rev
+    |> Result.map_error (fun e -> (input.pos, e))
 
   module In_channel_input = struct
     type t = in_channel
 
     module Monad = Id_monad
 
-    let read_string = really_input_string
+    let read_string size input =
+      try Result.ok @@ really_input_string size input
+      with End_of_file -> Result.Error premature_end
 
-    let read_char = input_char
+    let read_char input =
+      try Result.ok @@ input_char input
+      with End_of_file -> Result.Error premature_end
   end
 
   module In_channel_parser = Make_parser (In_channel_input)
@@ -145,13 +159,13 @@ module Make (Sexp : Sexp) = struct
   let input_opt ic =
     let pos = LargeFile.pos_in ic in
     match In_channel_parser.parse ic with
-    | x -> Ok (Some x)
+    | Ok x -> Ok (Some x)
+    | Error msg -> Error msg
     | exception End_of_file ->
       if LargeFile.pos_in ic = pos then
         Ok None
       else
         Error premature_end
-    | exception Parse_error msg -> Error msg
 
   let input ic =
     match input_opt ic with

--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -42,7 +42,7 @@ module Make (Sexp : Sexp) = struct
 
     let rec parse_atom input len =
       Input.read_char input >>= function
-      | Ok c when '0' <= c && c <= '9' ->
+      | Ok ('0' .. '9' as c) ->
         let len = (len * 10) + int_of_digit c in
         if len > Sys.max_string_length then
           return @@ parse_error "atom too big to represent"

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -69,4 +69,26 @@ module Make (Sexp : Sexp) : sig
   (** [output oc sexp] outputs the S-expression [sexp] converted to its
       canonical form to channel [oc]. *)
   val to_channel : out_channel -> Sexp.t -> unit
+
+  module type Input = sig
+    type t
+
+    module Monad : sig
+      type 'a t
+
+      val return : 'a -> 'a t
+
+      val bind : 'a t -> ('a -> 'b t) -> 'b t
+    end
+
+    val read_string : t -> int -> (string, string) result Monad.t
+
+    val read_char : t -> (char, string) result Monad.t
+  end
+
+  module Make_parser (Input : Input) : sig
+    val parse : Input.t -> (Sexp.t, string) result Input.Monad.t
+
+    val parse_many : Input.t -> (Sexp.t list, string) result Input.Monad.t
+  end
 end

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -27,8 +27,8 @@ module type Sexp = sig
 end
 
 module Make (Sexp : Sexp) : sig
-  include module type of Result
   (** {2 Parsing} *)
+  include module type of Result
 
   (** [parse_string s] parses a single S-expression encoded in canonical form in
       [s]. It is an error for [s] to contain a S-expression followed by more

--- a/test/test.ml
+++ b/test/test.ml
@@ -73,11 +73,11 @@ let%expect_test _ =
 
 let%expect_test _ =
   parse "(a)";
-  [%expect {| Error "invalid character" |}]
+  [%expect {| Error "invalid character 'a'" |}]
 
 let%expect_test _ =
   parse "(:)";
-  [%expect {| Error "invalid character" |}]
+  [%expect {| Error "invalid character ':'" |}]
 
 let%expect_test _ =
   parse "(4:foo)";
@@ -104,12 +104,14 @@ let sexp_then_stuff s =
   close_in ic;
   Lazy.force delete
 
-let%expect_test _ = sexp_then_stuff "(3:foo)(3:foo)";
+let%expect_test _ =
+  sexp_then_stuff "(3:foo)(3:foo)";
   [%expect {|
     Ok "(3:foo)"
     ( |}]
 
-let%expect_test _ = sexp_then_stuff "(3:foo)Additional_stuff";
+let%expect_test _ =
+  sexp_then_stuff "(3:foo)Additional_stuff";
   [%expect {|
     Ok "(3:foo)"
     A |}]


### PR DESCRIPTION
The existing interface has been left untouched. The parser backend is now exposed and functorized over an arbitrary monad. The implementation is a bit verbose due to the lack of monadic binding syntax and the bareness of `Result` in 4.02.3.

Further considerations :
* I could depend on base to get the `Monad` interface definition instead of introducing it for the bazillion time, but that would require 4.03.
* I could provide Lwt driver in an optional library, but that may be overzealous.