### PR TITLE
Do not use result module

### DIFF
--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -14,7 +14,6 @@ end
 
 module Make (Sexp : Sexp) = struct
   open Sexp
-  include Result
 
   module type Input = sig
     type t
@@ -26,7 +25,7 @@ module Make (Sexp : Sexp) = struct
     val read_char : t -> (char, string) result Monad.t
   end
 
-  let parse_error f = Format.ksprintf (fun msg -> Result.Error msg) f
+  let parse_error f = Format.ksprintf (fun msg -> Error msg) f
 
   let invalid_character c = parse_error "invalid character %C" c
 

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -28,7 +28,6 @@ end
 
 module Make (Sexp : Sexp) : sig
   (** {2 Parsing} *)
-  include module type of Result
 
   (** [parse_string s] parses a single S-expression encoded in canonical form in
       [s]. It is an error for [s] to contain a S-expression followed by more

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,4 @@
 (library
  (public_name csexp)
+ (flags -open Result)
  (libraries result))


### PR DESCRIPTION
I'm not sure why it was included in the interface, but it seems like it
shouldn't belong there.

Also, I've changed the result module to be used without changing the
code. This makes it easier to embed csexp in places where `result` isn't
present.