### PR TITLE
New parsing functor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ clean:
 all-supported-ocaml-versions:
 	dune runtest --workspace dune-workspace.dev
 
-.PHONY: default install uninstall reinstall clean
+.PHONY: default install uninstall reinstall clean test

--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -32,9 +32,9 @@ module Make (Sexp : Sexp) = struct
       val bind : 'a t -> ('a -> 'b t) -> 'b t
     end
 
-    val read_string : t -> int -> string option Monad.t
-
     val read_char : t -> char option Monad.t
+
+    val read_string : t -> int -> string option Monad.t
   end
 
   let parse_error f = Format.ksprintf (fun msg -> Error msg) f

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -130,7 +130,9 @@ module Make (Sexp : Sexp) : sig
   end
   [@@deprecated "Use Input2 instead"]
 
-  module Make_parser (Input : Input [@warning "-3"]) : sig
+  [@@@warning "-3"]
+
+  module Make_parser (Input : Input) : sig
     val parse : Input.t -> (Sexp.t, string) Result.t Input.Monad.t
 
     val parse_many : Input.t -> (Sexp.t list, string) Result.t Input.Monad.t


### PR DESCRIPTION
Following the issue raised [here](https://github.com/ocaml-dune/csexp/pull/6#discussion_r445374659), this PR proposes a new parsing API where end of input conditions are explicit:

```
    (** [read_char source] reads a single character from the input. Returns
        [None] if the end of input has been reached..*)
    val read_char : t -> char option Monad.t

    (** [read_string source size] reads exactly [size] bytes from [source] and
        return them as a string. Returns [None] if there are less than [size]
        characters available in the input. *)
    val read_string : t -> int -> string option Monad.t
```

This allows to react to end-of-input conditions without swallowing other kind of IO errors.