### PR TITLE
[WIP] Add feed API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+- Add a "feed" API for parsing. This new API let the user feed
+  characters one by one to the parser. It gives more control to the
+  user and the handling of IO errors is simpler and more explicit
+  (#9, @jeremiedimino)
+
+- Fixes `input_opt`; it was could never return [None] (#9, fixes #7,
+  @jeremiedimino)
+
+- Fixes `parse_many`; it was returning s-expressions in the wrong
+  order (#10, @rgrinberg)
+
 # 1.2.3
 
 - Fix `parse_string_many`; it used to fail on all inputs (#6, @rgrinberg)

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ clean:
 all-supported-ocaml-versions:
 	dune runtest --workspace dune-workspace.dev
 
-.PHONY: default install uninstall reinstall clean
+.PHONY: default install uninstall reinstall clean test

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -71,14 +71,279 @@ module Make (Sexp : Sexp) : sig
 
   (** {3 Low level parser}
 
-      Low level parsing interface with fine-grain control over the input monad.
-      Suitable for Lwt or Async integration. *)
+      For efficiently parsing from sources other than strings or input channel.
+      For instance in Lwt or Async programs. *)
+
+  module Parser : sig
+    (** The [Parser] module offers an API that is a balance between sharing the
+        common logic of parsing canonical S-expressions while allowing to write
+        parsers that are as efficient as possible, both in terms of speed and
+        allocations. A carefully written parser using this API will be:
+
+        - fast
+        - perform minimal allocations
+        - perform zero [caml_modify] (a slow function of the OCaml runtime that
+          is emitted when mutating a constructed value)
+
+        {2 Lexers}
+
+        To parse using this API, you must first create a lexer via
+        {!Lexer.create}. The lexer is responsible for scanning the input and
+        forming tokens. The user must feed characters read from the input one by
+        one to the lexer until it yields a token. For instance:
+
+        {[
+          # let lexer = Lexer.create ();;
+          val lexer : Lexer.t = <abstract>
+          # Lexer.feed lexer '(';;
+          - : [ `atom | `other ] Lexer.token = Lparen
+          # Lexer.feed lexer ')';;
+          - : [ `atom | `other ] Lexer.token = Rparen
+        ]}
+
+        When the lexer doesn't have enough to return a token, it simply returns
+        the special token {!Lexer.Await}:
+
+        {[
+          # Lexer.feed lexer '1';;
+          - : [ `atom | `other ] Lexer.token = Await
+        ]}
+
+        Note that since atoms of canonical S-expressions do not need quoting,
+        they are always represented as a contiguous sequence of characters that
+        don't need further processing. To achieve maximum efficiency, the lexer
+        only returns the length of the atom and it is the responsibility of the
+        caller to extract the atom from the input source:
+
+        {[
+          # Lexer.feed lexer '2';;
+          - : [ `atom | `other ] Lexer.token = Await
+          # Lexer.feed lexer ':';;
+          - : [ `atom | `other ] Lexer.token = Atom 2
+        ]}
+
+        When getting [Atom n], the caller should then proceed to read the next
+        [n] characters of the input as a string. For instance, if the input is
+        an [in_channel] the caller should proceed with
+        [really_input_string ic n].
+
+        Finally, when the end of input is reached the user should call
+        {!Lexer.feed_eoi} to make sure the lexer is not awaiting more input. If
+        that is the case, {!Lexer.feed_eoi} will raise:
+
+        {[
+          # Lexer.feed lexer '1';;
+          - : [ `atom | `other ] Lexer.token = Await
+          # Lexer.feed_eoi lexer;;
+          Exception: Parse_error "premature end of input".
+        ]}
+
+        {2 Parsing stacks}
+
+        The lexer doesn't keep track of the structure of the S-expressions. In
+        order to construct a whole structured S-expressions, the caller must
+        maintain a parsing stack via the {!Stack} module. A {!Stack.t} value
+        simply represent a parsed prefix in reverse order.
+
+        For instance, the prefix "1:x((1:y1:z)" will be represented as:
+
+        {[ Sexp (List [ Atom "y"; Atom "z" ], Open (Sexp (Atom "x", Empty))) ]}
+
+        The {!Stack} module offers various primitives to open or close
+        parentheses or insert an atom. And for convenience it provides a
+        function {!Stack.add_token} that takes the output of {!Lexer.feed}
+        directly:
+
+        {[
+          # Stack.add_token Rparen Empty;;
+          - : Stack.t = Open Empty
+          # Stack.add_token Lparen (Open Empty);;
+          - : Stack.t = Sexp (List [], Empty)
+        ]}
+
+        Note that {!Stack.add_token} doesn't accept [Atom _]. This is enforced
+        at the type level by a GADT. The reason for this is that in order to
+        insert an atom, the user must have fetched the contents of the atom
+        themselves. In order to insert an atom into a stack, you can use the
+        function {!Stack.add_atom}:
+
+        {[
+          # Stack.add_atom "foo" (Open Empty);;
+          - : Stack.t = Sexp (Atom "foo", Open Empty)
+        ]}
+
+        When parsing is finished, one may call the function {!Stack.to_list} in
+        order to extract all the toplevel S-expressions from the stack:
+
+        {[
+          # Stack.to_list (Sexp (Atom "x", Sexp (List [Atom "y"], Empty)));;
+          - : Sexp.t list = [List [Atom "y"; Atom "x"]]
+        ]}
+
+        If instead you want to stop parsing as soon a single full S-expression
+        has been discovered, you can match on the structure of the stack. If the
+        stack is of the form [Sexp (_, Empty)], then you know that exactly one
+        S-expression has been parsed and you can stop there.
+
+        {2 Parsing errors}
+
+        In order to reduce allocations to a minumim, parsing errors are reported
+        via the exception {!Parse_error}. It is the responsibility of the caller
+        to catch this exception and return it as an [Error _] value. Functions
+        that may raise [Parse_error] are documented as such.
+
+        When extracting an atom and the input doesn't have enough characters
+        left, the user may raise [Parse_error premature_end_of_input]. This will
+        produce an error message similar to what the various high-level
+        functions of this library produce.
+
+        {2 Building a parsing function}
+
+        Parsing functions should always follow the following pattern:
+
+        + create a lexer and start with an empty parsing stack
+        + iterate over the input, feeding the lexer characters one by one. When
+          the lexer returns [Atom n], fetch the next [n] characters from the
+          input to form an atom
+        + update the stack via [Stack.add_atom] or [Stack.add_token]
+        + if parsing the whole input, call [Lexer.feed_eoi] when the end of
+          input is reached, otherwise stop as soon as the stack is of the form
+          [Sexp (_, Empty)] -
+
+        For instance, to parse a string as a list of S-expressions:
+
+        {[
+          module Sexp = struct
+            type t =
+              | Atom of string
+              | List of t list
+          end
+
+          module Csexp = Csexp.Make (Sexp)
+
+          let extract_atom s pos len =
+            match String.sub s pos len with
+            | exception _ ->
+              (* Turn out-of-bounds errors into [Parse_error] *)
+              raise (Parse_error premature_end_of_input)
+            | s -> s
+
+          let parse_string =
+            let open Csexp.Parser in
+            let rec loop s pos len lexer stack =
+              if pos = len then (
+                Lexer.feed_eoi lexer;
+                Stack.to_list stack
+              ) else
+                match Lexer.feed lexer (String.unsafe_get s pos) with
+                | Atom atom_len ->
+                  let atom = extract_atom s (pos + 1) atom_len in
+                  loop s (pos + 1 + atom) len lexer (Stack.add_atom atom stack)
+                | (Await | Lparen | Rparen) as x ->
+                  loop s (pos + 1) len lexer (Stack.add_token x stack)
+            in
+            fun s ->
+              match loop s 0 (String.length s) (Lexer.create ()) Empty with
+              | v -> Ok v
+              | exception Parse_error msg -> Error msg
+        ]} *)
+
+    exception Parse_error of string
+
+    (** Error message signaling the end of input was reached prematurely. You
+        can use this when extracting an atom from the input and the input
+        doesn't have enough characters. *)
+    val premature_end_of_input : string
+
+    module Lexer : sig
+      (** Lexical analyser *)
+
+      type t
+
+      val create : unit -> t
+
+      type _ token =
+        | Await : [> `other ] token
+        | Lparen : [> `other ] token
+        | Rparen : [> `other ] token
+        | Atom : int -> [> `atom ] token
+
+      (** Feed a character to the parser.
+
+          @raise Parse_error *)
+      val feed : t -> char -> [ `other | `atom ] token
+
+      (** Feed the end of input to the parser.
+
+          You should call this function when the end of input has been reached
+          in order to ensure that the lexer is not awaiting more input, which
+          would be an error.
+
+          @raise Parse_error if the lexer is awaiting more input *)
+      val feed_eoi : t -> unit
+    end
+
+    module Stack : sig
+      (** Parsing stack *)
+
+      type t =
+        | Empty
+        | Open of t
+        | Sexp of Sexp.t * t
+
+      (** Extract the list of full S-expressions contained in a stack.
+
+          For instance:
+
+          {[
+            # to_list (Sexp (Atom "y", Sexp (Atom "x", Empty)));;
+            - : Stack.t list = [Atom "x"; Atom "y"]
+          ]}
+          @raise Parse_error if the stack contains open parentheses that has not
+          been closed. *)
+      val to_list : t -> Sexp.t list
+
+      (** Add a left parenthesis. *)
+      val open_paren : t -> t
+
+      (** Add a right parenthesis. Raise [Parse_error] if the stack contains no
+          opened parentheses.
+
+          For instance:
+
+          {[
+            # close_paren (Sexp (Atom "y", Sexp (Atom "x", Open Empty)));;
+            - : Stack.t = Sexp (List [Atom "x"; Atom "y"], Empty)
+          ]}
+          @raise Parse_error if the stack contains no open open parenthesis. *)
+      val close_paren : t -> t
+
+      (** Insert an atom in the parsing stack:
+
+          {[
+            # add_atom "foo" Empty;;
+            - : Stack.t = Sexp (Atom "foo", Empty)
+          ]} *)
+      val add_atom : string -> t -> t
+
+      (** Add a token as returned by the lexer.
+
+          @raise Parse_error *)
+      val add_token : [ `other ] Lexer.token -> t -> t
+    end
+  end
+
+  (** {3 Deprecated low-level parser} *)
+
+  (** The above are deprecated as the {!Input} signature does not allow to
+      distinguish between IO errors and end of input conditions. Additionally,
+      the use of monads tend to produce parsers that allocates a lot.
+
+      It is recommended to use the {!Parser} module instead. *)
 
   module type Input = sig
-    (** Type of an input source. *)
     type t
 
-    (** Monad wrapping values returned by the input source *)
     module Monad : sig
       type 'a t
 
@@ -87,22 +352,18 @@ module Make (Sexp : Sexp) : sig
       val bind : 'a t -> ('a -> 'b t) -> 'b t
     end
 
-    (** [read_string source size] reads exactly [size] bytes from [source] and
-        return them as a string. Reaching the end of the input before [size]
-        bytes have been read is an [Error]. *)
     val read_string : t -> int -> (string, string) Result.t Monad.t
 
-    (** [read_char source] is [read_string source 1], except the result is
-        returned as a single character.*)
     val read_char : t -> (char, string) Result.t Monad.t
   end
+  [@@deprecated "Use Parser module instead"]
+
+  [@@@warning "-3"]
 
   module Make_parser (Input : Input) : sig
-    (** Read exactly one canonical S-expressions from the input. Note that this
-        function never raises [End_of_file]. Instead, it returns [Error]. *)
     val parse : Input.t -> (Sexp.t, string) Result.t Input.Monad.t
 
-    (** Read many S-expressions until the end of input is reached. *)
     val parse_many : Input.t -> (Sexp.t list, string) Result.t Input.Monad.t
   end
+  [@@deprecated "Use Parser module instead"]
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -73,11 +73,11 @@ let%expect_test _ =
 
 let%expect_test _ =
   parse "(a)";
-  [%expect {| Error "invalid character 'a'" |}]
+  [%expect {| Error "invalid character 'a', expected '(', ')' or '0'..'9'" |}]
 
 let%expect_test _ =
   parse "(:)";
-  [%expect {| Error "invalid character ':'" |}]
+  [%expect {| Error "invalid character ':', expected '(', ')' or '0'..'9'" |}]
 
 let%expect_test _ =
   parse "(4:foo)";


### PR DESCRIPTION
Alternative to #8. This PR proposes to add a direct parsing API (no functors involved) where the user can feed characters to the parser one by one. It is similar to the API of Parsexp.

```ocaml
  module Parser : sig
    (** Low-level parser *)

    type t

    val create : unit -> t

    (** Feed a character to the parser. The states and stack are updated
        accordingly. Note that the stack is passed explicitely rather than
        stored in the state for performance reason; it avoids calls to
        [caml_modify] which are slow. *)
    val feed : t -> char -> Stack.t -> Stack.t

    (** Feed the end of input to the parser. Return the parsed S-expressions
        contained in the stack. This functions raise if we were in the middle of
        parsing an atom or list. *)
    val feed_eoi : t -> Stack.t -> Sexp.t list
  end
```

It also fixes `input_opt` which couldn't return `None` before.