### PR TITLE
Fix parse_string_many order

### DIFF
--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -151,7 +151,7 @@ module Make (Sexp : Sexp) = struct
   let parse_string_many s =
     let input : String_input.t = { buf = s; pos = 0 } in
     match String_parser.parse_many input with
-    | Ok l -> Ok (List.rev l)
+    | Ok l -> Ok l
     | Error e -> Error (input.pos, e)
 
   module In_channel_input = struct

--- a/test/test.ml
+++ b/test/test.ml
@@ -139,4 +139,4 @@ let%expect_test "parse_string_many - parse a single csexp" =
 
 let%expect_test "parse_string_many - parse many csexp" =
   parse_many "(3:foo)(3:bar)";
-  [%expect {| Ok "(3:bar)"Ok "(3:foo)" |}]
+  [%expect {| Ok "(3:foo)"Ok "(3:bar)" |}]


### PR DESCRIPTION
There was an unnecessary `List.rev` that wasn't removed after fixing the bug.

@jeremiedimino fixes the bug you just noticed.