### PR TITLE
Result.{result => t}

### DIFF
--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -17,7 +17,7 @@ module Make (Sexp : Sexp) = struct
 
   (* This is to keep compatibility with 4.02 without writing [Result.]
      everywhere *)
-  type ('a, 'b) result = ('a, 'b) Result.result =
+  type ('a, 'b) result = ('a, 'b) Result.t =
     | Ok of 'a
     | Error of 'b
 


### PR DESCRIPTION
Using `Result.result` instead of `Result.t` makes it impossible to use the Stdlib `Result` when vendoring this package (eg when building `dune` on Windows), which is a headache.

I only took a quick glance at the compatibility package https://github.com/janestreet/result, but it seems to define `Result.t` as well as `Result.result` so it looks like doing this renaming would leave everyone happy :)