### PR TITLE
Upstream temporary opam patch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+- The project now builds with dune 1.11.0 and onward (#12, @voodoos)
+
 # 1.3.1
 
 - Fix compatibility with 4.02.3

--- a/csexp.opam
+++ b/csexp.opam
@@ -31,9 +31,9 @@ bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.02.3"}
-  "ppx_expect" {with-test}
   "result" {>= "1.5"}
 ]
+dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
 build: [
   ["dune" "subst"] {pinned}
   [
@@ -44,8 +44,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#   "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/ocaml-dune/csexp.git"

--- a/csexp.opam.template
+++ b/csexp.opam.template
@@ -1,0 +1,14 @@
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+#   "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,9 @@
  (name csexp)
  (depends
    (ocaml (>= 4.02.3))
-   (ppx_expect :with-test)
+;  (ppx_expect :with-test)
+; Disabled because of a dependency cycle 
+; (see https://github.com/ocaml-opam/opam-depext/issues/121)
    (result (>= 1.5)))
  (synopsis "Parsing and printing of S-expressions in Canonical form")
  (description "


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/17186

> This is only a mitigation until opam 2.1 comes out and is wildly used in CIs.