### PR TITLE
Get rid of result and drop 4.02

### DIFF
--- a/csexp.opam
+++ b/csexp.opam
@@ -30,8 +30,7 @@ doc: "https://ocaml-dune.github.io/csexp/"
 bug-reports: "https://github.com/ocaml-dune/csexp/issues"
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.02.3"}
-  "result" {>= "1.5"}
+  "ocaml" {>= "4.03.0"}
 ]
 dev-repo: "git+https://github.com/ocaml-dune/csexp.git"
 build: [

--- a/dune-project
+++ b/dune-project
@@ -17,11 +17,11 @@
 (package
  (name csexp)
  (depends
-   (ocaml (>= 4.02.3))
+   (ocaml (>= 4.03.0))
 ;  (ppx_expect :with-test)
 ; Disabled because of a dependency cycle 
 ; (see https://github.com/ocaml-opam/opam-depext/issues/121)
-   (result (>= 1.5)))
+   )
  (synopsis "Parsing and printing of S-expressions in Canonical form")
  (description "
 This library provides minimal support for Canonical S-expressions

--- a/src/csexp.ml
+++ b/src/csexp.ml
@@ -15,15 +15,15 @@ end
 module type S = sig
   type sexp
 
-  val parse_string : string -> (sexp, int * string) Result.t
+  val parse_string : string -> (sexp, int * string) result
 
-  val parse_string_many : string -> (sexp list, int * string) Result.t
+  val parse_string_many : string -> (sexp list, int * string) result
 
-  val input : in_channel -> (sexp, string) Result.t
+  val input : in_channel -> (sexp, string) result
 
-  val input_opt : in_channel -> (sexp option, string) Result.t
+  val input_opt : in_channel -> (sexp option, string) result
 
-  val input_many : in_channel -> (sexp list, string) Result.t
+  val input_many : in_channel -> (sexp list, string) result
 
   val serialised_length : sexp -> int
 
@@ -83,30 +83,24 @@ module type S = sig
       val bind : 'a t -> ('a -> 'b t) -> 'b t
     end
 
-    val read_string : t -> int -> (string, string) Result.t Monad.t
+    val read_string : t -> int -> (string, string) result Monad.t
 
-    val read_char : t -> (char, string) Result.t Monad.t
+    val read_char : t -> (char, string) result Monad.t
   end
   [@@deprecated "Use Parser module instead"]
 
   [@@@warning "-3"]
 
   module Make_parser (Input : Input) : sig
-    val parse : Input.t -> (sexp, string) Result.t Input.Monad.t
+    val parse : Input.t -> (sexp, string) result Input.Monad.t
 
-    val parse_many : Input.t -> (sexp list, string) Result.t Input.Monad.t
+    val parse_many : Input.t -> (sexp list, string) result Input.Monad.t
   end
   [@@deprecated "Use Parser module instead"]
 end
 
 module Make (Sexp : Sexp) = struct
   open Sexp
-
-  (* This is to keep compatibility with 4.02 without writing [Result.]
-     everywhere *)
-  type ('a, 'b) result = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
 
   module Parser = struct
     exception Parse_error of string
@@ -370,9 +364,9 @@ module Make (Sexp : Sexp) = struct
 
     module Monad : Monad
 
-    val read_string : t -> int -> (string, string) Result.t Monad.t
+    val read_string : t -> int -> (string, string) result Monad.t
 
-    val read_char : t -> (char, string) Result.t Monad.t
+    val read_char : t -> (char, string) result Monad.t
   end
 
   module Make_parser (Input : Input) = struct

--- a/src/csexp.mli
+++ b/src/csexp.mli
@@ -353,18 +353,18 @@ module type S = sig
       val bind : 'a t -> ('a -> 'b t) -> 'b t
     end
 
-    val read_string : t -> int -> (string, string) Result.t Monad.t
+    val read_string : t -> int -> (string, string) result Monad.t
 
-    val read_char : t -> (char, string) Result.t Monad.t
+    val read_char : t -> (char, string) result Monad.t
   end
   [@@deprecated "Use Parser module instead"]
 
   [@@@warning "-3"]
 
   module Make_parser (Input : Input) : sig
-    val parse : Input.t -> (sexp, string) Result.t Input.Monad.t
+    val parse : Input.t -> (sexp, string) result Input.Monad.t
 
-    val parse_many : Input.t -> (sexp list, string) Result.t Input.Monad.t
+    val parse_many : Input.t -> (sexp list, string) result Input.Monad.t
   end
   [@@deprecated "Use Parser module instead"]
 end

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,2 @@
 (library
- (public_name csexp)
- (libraries result))
+ (public_name csexp))


### PR DESCRIPTION
Merlin is no longer using 4.02, the time has come to finally get rid of this.